### PR TITLE
Build branch support added, bug fix of the issue with owner edit/save.

### DIFF
--- a/CCNet.Build.AzureUpload/CCNet.Build.AzureUpload.csproj
+++ b/CCNet.Build.AzureUpload/CCNet.Build.AzureUpload.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Args.cs" />
+    <Compile Include="CloudStorageExtensions.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/CCNet.Build.AzureUpload/CloudStorageExtensions.cs
+++ b/CCNet.Build.AzureUpload/CloudStorageExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.IO;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace CCNet.Build.AzureUpload
+{
+	internal static class CloudStorageExtensions
+	{
+		public static void UploadFile(this CloudBlobContainer container, string file, string blobName)
+		{
+			var blob = container.GetBlockBlobReference(blobName);
+			var extension = Path.GetExtension(file).ToLowerInvariant();
+
+			switch (extension)
+			{
+				case ".txt":
+					blob.Properties.ContentType = "text/plain";
+					break;
+
+				case ".xml":
+				case ".cscfg":
+					blob.Properties.ContentType = "text/xml";
+					break;
+
+				case ".zip":
+					blob.Properties.ContentType = "application/zip";
+					break;
+			}
+
+			Console.WriteLine("Local name: {0}", file);
+			Console.WriteLine("Blob name: {0}", blob.Name);
+
+			Console.Write("Uploading file... ");
+			blob.UploadFromFile(file, FileMode.Open);
+			Console.WriteLine("OK");
+		}
+	}
+}

--- a/CCNet.Build.Reconfigure/Configuration/CCNetConfigExtensions.cs
+++ b/CCNet.Build.Reconfigure/Configuration/CCNetConfigExtensions.cs
@@ -79,7 +79,7 @@ namespace CCNet.Build.Reconfigure
 
 			foreach (var arg in arguments)
 			{
-				if (arg.Item1 == null)
+				if (arg.Item1 == null || arg.Item2 == null)
 					continue;
 
 				if (arg.Item1.Length == 0)

--- a/CCNet.Build.Reconfigure/Configuration/Settings/BasicProjectConfiguration.cs
+++ b/CCNet.Build.Reconfigure/Configuration/Settings/BasicProjectConfiguration.cs
@@ -33,7 +33,7 @@ namespace CCNet.Build.Reconfigure
 				if (String.IsNullOrEmpty(Branch))
 					return "$(nugetUrl)/api/v2";
 
-				return $"$(nugetUrl)/private/{Branch}/api/v2";
+				return $"$(nugetUrl)/private/{Branch}/api/v2;$(nugetUrl)/api/v2";
 			}
 		}
 

--- a/CCNet.Build.Reconfigure/Configuration/Settings/CloudServiceProjectConfiguration.cs
+++ b/CCNet.Build.Reconfigure/Configuration/Settings/CloudServiceProjectConfiguration.cs
@@ -28,6 +28,11 @@ namespace CCNet.Build.Reconfigure
 			get { return String.Format(@"{0}\ServiceConfiguration.cscfg", SourceDirectoryRelease); }
 		}
 
+		public string ReleaseDirectoryExtensions
+		{
+			get { return String.Format(@"{0}\Extensions", SourceDirectoryRelease); }
+		}
+
 		public string SourceDirectoryPublished
 		{
 			get { return String.Format(@"{0}\app.publish", SourceDirectoryRelease); }

--- a/CCNet.Build.Reconfigure/Configuration/Settings/CloudServiceProjectConfiguration.cs
+++ b/CCNet.Build.Reconfigure/Configuration/Settings/CloudServiceProjectConfiguration.cs
@@ -30,7 +30,7 @@ namespace CCNet.Build.Reconfigure
 
 		public string ReleaseDirectoryExtensions
 		{
-			get { return String.Format(@"{0}\Extensions", SourceDirectoryRelease); }
+			get { return String.Format(@"{0}\app.publish\Extensions", SourceDirectoryRelease); }
 		}
 
 		public string SourceDirectoryPublished

--- a/CCNet.Build.Reconfigure/Configuration/Shared/ProjectExtensions.Publish.cs
+++ b/CCNet.Build.Reconfigure/Configuration/Shared/ProjectExtensions.Publish.cs
@@ -9,6 +9,11 @@ namespace CCNet.Build.Reconfigure
 			return String.Format(@"{0}\publish", project.WorkingDirectory);
 		}
 
+		public static string WorkingDirectoryPublishExtensions(this IProjectPublish project)
+		{
+			return String.Format(@"{0}\publish\Extensions", project.WorkingDirectory);
+		}
+
 		public static string PublishFileName(this IProjectPublish project)
 		{
 			return String.Format(@"{0}.publish.zip", project.Name);

--- a/CCNet.Build.Reconfigure/Configuration2/Tools/ISetupPackages.cs
+++ b/CCNet.Build.Reconfigure/Configuration2/Tools/ISetupPackages.cs
@@ -35,7 +35,7 @@ namespace CCNet.Build.Reconfigure
 			if (String.IsNullOrEmpty(config.Branch))
 				return "$(nugetUrl)/api/v2";
 
-			return $"$(nugetUrl)/private/{config.Branch}/api/v2";
+			return $"$(nugetUrl)/private/{config.Branch}/api/v2;$(nugetUrl)/api/v2";
 		}
 	}
 }

--- a/CCNet.Build.Reconfigure/Confluence/PageBuilder.cs
+++ b/CCNet.Build.Reconfigure/Confluence/PageBuilder.cs
@@ -355,15 +355,18 @@ namespace CCNet.Build.Reconfigure
 
 		private static string ResolveProjectName(string pageName, out ProjectType projectType)
 		{
-			if (pageName.Contains("//"))
+			if (pageName.StartsWith("~"))
 			{
-				var pair = pageName.Split(new[] { "//" }, StringSplitOptions.RemoveEmptyEntries);
-				if (pair.Length != 2)
+				var pair = pageName.Split(new[] { "~" }, StringSplitOptions.None);
+				if (pair.Length != 3
+					|| !pair[1].StartsWith(" ")
+					|| !pair[1].EndsWith(" ")
+					|| !pair[2].StartsWith(" "))
 				{
 					throw new ArgumentException($"Page name '{pageName}' does not look well-formed.");
 				}
 
-				pageName = pair[1].TrimStart();
+				pageName = pair[2].TrimStart();
 			}
 
 			if (pageName != pageName.AsciiOnly('.', ' ').CleanWhitespaces())

--- a/CCNet.Build.Reconfigure/Confluence/Pages/BasicProjectPage.cs
+++ b/CCNet.Build.Reconfigure/Confluence/Pages/BasicProjectPage.cs
@@ -139,7 +139,9 @@ namespace CCNet.Build.Reconfigure
 					"p",
 					new XElement(
 						"a",
-						new XAttribute("href", $"{Config.NuGetUrl}/packages/{ProjectName}/"),
+						BranchName == null
+							? new XAttribute("href", $"{Config.NuGetUrl}/packages/{ProjectName}/")
+							: new XAttribute("href", $"{Config.NuGetUrl}/private/{BranchName}/packages/__{BranchName.ToLower()}__{ProjectName}/"),
 						PageDocument.BuildImage($"{Config.NuGetUrl}/favicon.ico"),
 						"$nbsp$NuGet package"));
 
@@ -150,7 +152,11 @@ namespace CCNet.Build.Reconfigure
 				"p",
 				new XElement(
 					"a",
-					new XAttribute("href", $"{Config.CCNetUrl}/server/{Type.ServerName()}/project/{ProjectName}/ViewProjectReport.aspx"),
+					new XAttribute(
+						"href",
+						BranchName == null
+							? $"{Config.CCNetUrl}/server/{Type.ServerName()}/project/{ProjectName}/ViewProjectReport.aspx"
+							: $"{Config.CCNetUrl}/server/{Type.ServerName()}/project/{ProjectName}-{BranchName}/ViewProjectReport.aspx"),
 					PageDocument.BuildImage($"{Config.CCNetUrl}/favicon.ico"),
 					"$nbsp$Build project"));
 
@@ -229,7 +235,7 @@ namespace CCNet.Build.Reconfigure
 
 			var path = TfsPath;
 
-			if (ProjectBranch == null && !CheckTfsPathArea(path, AreaName))
+			if (BranchName == null && !CheckTfsPathArea(path, AreaName))
 			{
 				throw new InvalidOperationException($"TFS path '{path}' seems not conforming with area name '{AreaName}'.");
 			}
@@ -290,13 +296,13 @@ namespace CCNet.Build.Reconfigure
 			if (ProjectUid == Guid.Empty)
 				return null;
 
-			if (ProjectBranch == null)
+			if (BranchName == null)
 			{
 				return new Tuple<string, Guid>(ProjectName, ProjectUid);
 			}
 
 			return new Tuple<string, Guid>(
-					string.Format("{0}-{1}", ProjectName, ProjectBranch),
+					string.Format("{0}-{1}", ProjectName, BranchName),
 					ProjectUid);
 		}
 

--- a/CCNet.Build.Reconfigure/Confluence/Pages/LibraryProjectPage.cs
+++ b/CCNet.Build.Reconfigure/Confluence/Pages/LibraryProjectPage.cs
@@ -53,16 +53,28 @@ namespace CCNet.Build.Reconfigure
 
 		private XElement RenderFramework()
 		{
-			return new XElement("td", BuildFramework(Framework));
+			return new XElement(
+				"td",
+				new XElement(
+					"div",
+					new XAttribute("class", "content-wrapper"),
+					new XElement(
+						"p",
+						BuildFramework(Framework))));
 		}
 
 		private XElement RenderDocumentation()
 		{
 			return new XElement(
 				"td",
-				BuildExplain(
-					"Документацияпроекта(XMLdocumentation)",
-					BuildDocumentation(Documentation)));
+				new XElement(
+					"div",
+					new XAttribute("class", "content-wrapper"),
+					new XElement(
+						"p",
+						BuildExplain(
+							"Документацияпроекта(XMLdocumentation)",
+							BuildDocumentation(Documentation)))));
 		}
 
 		private XElement RenderNamespace()

--- a/CCNet.Build.Reconfigure/Confluence/ProjectPage.cs
+++ b/CCNet.Build.Reconfigure/Confluence/ProjectPage.cs
@@ -17,7 +17,7 @@ namespace CCNet.Build.Reconfigure
 
 		public string AreaName { get; }
 		public string ProjectName { get; }
-		public string ProjectBranch { get; }
+		public string BranchName { get; }
 		public string Description { get; }
 		public string Owner { get; }
 		public ProjectStatus Status { get; }
@@ -41,7 +41,7 @@ namespace CCNet.Build.Reconfigure
 
 			AreaName = areaName;
 			ProjectName = projectName;
-			ProjectBranch = ParseProjectBranch(pageName, projectName);
+			BranchName = ParseBranchName(pageName);
 
 			m_page = pageName;
 			m_root = pageDocument.Root;
@@ -53,7 +53,10 @@ namespace CCNet.Build.Reconfigure
 			Status = ParseStatus(m_properties);
 		}
 
-		public string OrderKey => AreaName + ":" + ProjectName;
+		public string OrderKey =>
+			AreaName + ":"
+			+ ("ZZZ" + BranchName != null ? BranchName + ":" : null)
+			+ ProjectName;
 
 		private Dictionary<string, string> ParseProperties(XElement page)
 		{
@@ -78,11 +81,13 @@ namespace CCNet.Build.Reconfigure
 				if (code != null)
 					value = code.XValue();
 
-				var status = td.XElement("div/ac:structured-macro[@ac:name='status']/ac:parameter[@ac:name='title']|ac:structured-macro[@ac:name='status']/ac:parameter[@ac:name='title']");
+				const string statusXPath = "ac:structured-macro[@ac:name='status']/ac:parameter[@ac:name='title']";
+				var status = td.XElement($"div/p/{statusXPath}|div/{statusXPath}|{statusXPath}");
 				if (status != null)
 					value = status.XValue();
 
-				var user = td.XElements("div/ac:link/ri:user|ac:link/ri:user").Select(e => e.XAttribute("ri:userkey").Value).FirstOrDefault();
+				const string userXPath = "ac:link/ri:user";
+				var user = td.XElements($"div/{userXPath}|{userXPath}").Select(e => e.XAttribute("ri:userkey").Value).FirstOrDefault();
 				if (user != null)
 					value = user;
 
@@ -99,12 +104,12 @@ namespace CCNet.Build.Reconfigure
 			return map;
 		}
 
-		private string ParseProjectBranch(string pageName, string projectName)
+		private string ParseBranchName(string pageName)
 		{
-			if (pageName.IndexOf("//") < 0)
+			if (!pageName.StartsWith("~"))
 				return null;
 
-			return pageName.Substring(0, pageName.IndexOf("//")).TrimEnd();
+			return pageName.Substring(2, pageName.IndexOf("~", 2) - 3);
 		}
 
 		private string ParseDescription(Dictionary<string, string> properties)
@@ -160,18 +165,26 @@ namespace CCNet.Build.Reconfigure
 		{
 			return new XElement(
 				"td",
-				BuildExplain(
-					"Владелецпроекта(Owner)",
-					BuildOwner(Owner)));
+				new XElement(
+					"div",
+					new XAttribute("class", "content-wrapper"),
+					BuildExplain(
+						"Владелецпроекта(Owner)",
+						BuildOwner(Owner))));
 		}
 
 		private XElement RenderStatus()
 		{
 			return new XElement(
 				"td",
-				BuildExplain(
-					"Статуспроекта(Status)",
-					BuildStatus(Status)));
+				new XElement(
+					"div",
+					new XAttribute("class", "content-wrapper"),
+					new XElement(
+						"p",
+						BuildExplain(
+							"Статуспроекта(Status)",
+							BuildStatus(Status)))));
 		}
 
 		private XElement RenderProperties()
@@ -205,14 +218,18 @@ namespace CCNet.Build.Reconfigure
 		{
 			return new XElement(
 				"td",
-				PageDocument.BuildPageLink(m_page, ProjectName));
+				PageDocument.BuildPageLink(
+					m_page,
+					BranchName == null
+						? ProjectName
+						: $"~ {BranchName} ~ {ProjectName}"));
 		}
 
 		private XElement RenderTypeColumn()
 		{
 			return new XElement(
 				"td",
-				m_page.Replace(ProjectName, String.Empty).Trim());
+				m_page.Substring(m_page.IndexOf(ProjectName) + ProjectName.Length + 1));
 		}
 
 		public virtual void CheckPage(TfsClient client)
@@ -255,7 +272,7 @@ namespace CCNet.Build.Reconfigure
 		protected void ApplyTo(ProjectConfiguration config)
 		{
 			config.Name = ProjectName;
-			config.Branch = ProjectBranch;
+			config.Branch = BranchName;
 			config.Description = Description;
 			config.Category = AreaName;
 

--- a/CCNet.Build.Reconfigure/Program.cs
+++ b/CCNet.Build.Reconfigure/Program.cs
@@ -1529,14 +1529,7 @@ namespace CCNet.Build.Reconfigure
 					var filesToUpload = new List<string>();
 
 					writer.CbTag("CopyFiles", "from", project.ReleaseFileServiceConfiguration, "to", project.WorkingDirectoryPublish());
-					writer.CbTag("CreateDirectory", "path", project.WorkingDirectoryPublishExtensions());
-					writer.CbTag("CopyFilesWildcard",
-						"from", project.ReleaseDirectoryExtensions,
-						"wildcard", "*",
-						"to", project.WorkingDirectoryPublishExtensions());
-
 					filesToUpload.Add(Path.GetFileName(project.ReleaseFileServiceConfiguration));
-					filesToUpload.Add(Path.GetFileName(project.ReleaseDirectoryExtensions));
 
 					foreach (var vmSize in project.VmSizes)
 					{
@@ -1570,6 +1563,14 @@ namespace CCNet.Build.Reconfigure
 
 						filesToUpload.Add(publishName);
 					}
+
+					writer.CbTag("CreateDirectory", "path", project.WorkingDirectoryPublishExtensions());
+					writer.CbTag("CopyFilesWildcard",
+						"from", project.ReleaseDirectoryExtensions,
+						"wildcard", "*",
+						"to", project.WorkingDirectoryPublishExtensions());
+
+					filesToUpload.Add(Path.GetFileName(project.ReleaseDirectoryExtensions));
 
 					foreach (var fileToUpload in filesToUpload)
 					{

--- a/CCNet.Build.Reconfigure/Program.cs
+++ b/CCNet.Build.Reconfigure/Program.cs
@@ -527,7 +527,6 @@ namespace CCNet.Build.Reconfigure
 				.ToList();
 		}
 
-
 		private static XmlWriter WriteConfig(string filePath)
 		{
 			return new XmlTextWriter(filePath, Encoding.UTF8)
@@ -1523,7 +1522,14 @@ namespace CCNet.Build.Reconfigure
 					var filesToUpload = new List<string>();
 
 					writer.CbTag("CopyFiles", "from", project.ReleaseFileServiceConfiguration, "to", project.WorkingDirectoryPublish());
+					writer.CbTag("CreateDirectory", "path", project.WorkingDirectoryPublishExtensions());
+					writer.CbTag("CopyFilesWildcard",
+						"from", project.ReleaseDirectoryExtensions,
+						"wildcard", "*",
+						"to", project.WorkingDirectoryPublishExtensions());
+
 					filesToUpload.Add(Path.GetFileName(project.ReleaseFileServiceConfiguration));
+					filesToUpload.Add(Path.GetFileName(project.ReleaseDirectoryExtensions));
 
 					foreach (var vmSize in project.VmSizes)
 					{

--- a/CCNet.Build.Reconfigure/Program.cs
+++ b/CCNet.Build.Reconfigure/Program.cs
@@ -816,6 +816,7 @@ namespace CCNet.Build.Reconfigure
 				var args = new List<Arg>
 				{
 					new Arg("ProjectFile", Path.Combine(project.WorkingDirectorySource, $"{Util.ProjectNameToLocalName(project.Name)}.csproj")),
+					new Arg("BranchName", project.Branch),
 					new Arg("PackagesPath", project.WorkingDirectoryPackages),
 					new Arg("ReferencesPath", project.WorkingDirectoryReferences),
 					new Arg("TempPath", project.WorkingDirectoryTemp),
@@ -1011,6 +1012,7 @@ namespace CCNet.Build.Reconfigure
 						writer.WriteBuildArgs(
 							new Arg("ProjectType", project.Type),
 							new Arg("ProjectName", project.Name),
+							new Arg("BranchName", project.Branch),
 							new Arg(project.CustomAssemblyName != null ? "PackageId" : null, project.CustomAssemblyName),
 							new Arg("ProjectPath", project.WorkingDirectorySource),
 							new Arg("TempPath", project.WorkingDirectoryTemp),
@@ -1189,6 +1191,7 @@ namespace CCNet.Build.Reconfigure
 						writer.WriteBuildArgs(
 							new Arg("ProjectType", project.Type),
 							new Arg("ProjectName", project.Name),
+							new Arg("BranchName", project.Branch),
 							new Arg("ProjectPath", project.WorkingDirectorySource),
 							new Arg("TempPath", project.WorkingDirectoryTemp),
 							new Arg("TfsPath", project.TfsPath),
@@ -1262,6 +1265,7 @@ namespace CCNet.Build.Reconfigure
 						writer.WriteBuildArgs(
 							new Arg("ProjectType", project.Type),
 							new Arg("ProjectName", project.Name),
+							new Arg("BranchName", project.Branch),
 							new Arg("ProjectPath", project.WorkingDirectorySource),
 							new Arg("TempPath", project.WorkingDirectoryTemp),
 							new Arg("TfsPath", project.TfsPath),
@@ -1334,6 +1338,7 @@ namespace CCNet.Build.Reconfigure
 						writer.WriteBuildArgs(
 							new Arg("ProjectType", project.Type),
 							new Arg("ProjectName", project.Name),
+							new Arg("BranchName", project.Branch),
 							new Arg("ProjectPath", project.WorkingDirectorySource),
 							new Arg("TempPath", project.WorkingDirectoryTemp),
 							new Arg("TfsPath", project.TfsPath),
@@ -1438,6 +1443,7 @@ namespace CCNet.Build.Reconfigure
 						writer.WriteBuildArgs(
 							new Arg("ProjectType", project.Type),
 							new Arg("ProjectName", project.Name),
+							new Arg("BranchName", project.Branch),
 							new Arg("ProjectPath", project.WorkingDirectorySource),
 							new Arg("TempPath", project.WorkingDirectoryTemp),
 							new Arg("TfsPath", project.TfsPath),
@@ -1504,6 +1510,7 @@ namespace CCNet.Build.Reconfigure
 						writer.WriteBuildArgs(
 							new Arg("ProjectType", project.Type),
 							new Arg("ProjectName", project.Name),
+							new Arg("BranchName", project.Branch),
 							new Arg("ProjectPath", project.WorkingDirectorySource),
 							new Arg("ReferencesPath", project.WorkingDirectoryReferences),
 							new Arg("RelatedPath", project.WorkingDirectoryRelated()),

--- a/CCNet.Build.SetupPackages/Args.cs
+++ b/CCNet.Build.SetupPackages/Args.cs
@@ -12,6 +12,10 @@ namespace CCNet.Build.SetupPackages
 		{
 			get { return Current.Get<string>("ProjectFile"); }
 		}
+		public static string BranchName
+		{
+			get { return Current.IsEmpty("BranchName") ? null : Current.Get<string>("BranchName"); }
+		}
 
 		public static string ReferencesPath
 		{

--- a/CCNet.Build.SetupPackages/NuGet/NuGetPackage.cs
+++ b/CCNet.Build.SetupPackages/NuGet/NuGetPackage.cs
@@ -16,6 +16,10 @@ namespace CCNet.Build.SetupPackages
 				throw new ArgumentNullException(nameof(framework));
 
 			Framework = ParseFramework(framework);
+
+			if (!String.IsNullOrEmpty(Suffix))
+				throw new ArgumentException("Version is not expected to have suffixes here.", nameof(version));
+
 			Title = title;
 			Tags = tags;
 		}

--- a/CCNet.Build.SetupPackages/NuGet/NuGetPackage.cs
+++ b/CCNet.Build.SetupPackages/NuGet/NuGetPackage.cs
@@ -16,10 +16,6 @@ namespace CCNet.Build.SetupPackages
 				throw new ArgumentNullException(nameof(framework));
 
 			Framework = ParseFramework(framework);
-
-			if (!String.IsNullOrEmpty(Suffix))
-				throw new ArgumentException("Version is not expected to have suffixes here.", nameof(version));
-
 			Title = title;
 			Tags = tags;
 		}

--- a/CCNet.Build.SetupPackages/NuGet/NuGetReference.cs
+++ b/CCNet.Build.SetupPackages/NuGet/NuGetReference.cs
@@ -6,28 +6,45 @@ namespace CCNet.Build.SetupPackages
 	{
 		public string Id { get; private set; }
 		public Version Version { get; private set; }
-		public string Suffix { get; private set; }
+		public string Branch { get; private set; }
 
 		public NuGetReference(string id, string version)
 		{
+
 			if (String.IsNullOrEmpty(id))
 				throw new ArgumentNullException(nameof(id));
 
-			Id = id;
+			string prefix = null;
+
+			Id = ParseId(id, out prefix);
+
+			Branch = prefix;
 
 			if (String.IsNullOrEmpty(version))
 				throw new ArgumentNullException(nameof(version));
 
-			if (version.Contains("-"))
+			Version = new Version(version);
+		}
+
+		private static string ParseId(string id, out string prefix)
+		{
+			prefix = null;
+
+			if (String.IsNullOrEmpty(id))
+				return null;
+
+			var pair = id.Split(new[] { "__" }, StringSplitOptions.None);
+			if (pair.Length != 3
+				|| pair[0] != string.Empty
+				|| pair[1].Length == 0
+				|| pair[2].Length == 0)
 			{
-				var parts = version.Split(new[] { '-' }, 2);
-				Version = new Version(parts[0]);
-				Suffix = parts[1];
+				return id;
 			}
-			else
-			{
-				Version = new Version(version);
-			}
+
+			prefix = pair[1];
+
+			return pair[2];
 		}
 	}
 }

--- a/CCNet.Build.SetupPackages/NuGet/NuGetReference.cs
+++ b/CCNet.Build.SetupPackages/NuGet/NuGetReference.cs
@@ -6,6 +6,7 @@ namespace CCNet.Build.SetupPackages
 	{
 		public string Id { get; private set; }
 		public Version Version { get; private set; }
+		public string Suffix { get; private set; }
 		public string Branch { get; private set; }
 
 		public NuGetReference(string id, string version)
@@ -23,7 +24,16 @@ namespace CCNet.Build.SetupPackages
 			if (String.IsNullOrEmpty(version))
 				throw new ArgumentNullException(nameof(version));
 
-			Version = new Version(version);
+			if (version.Contains("-"))
+			{
+				var parts = version.Split(new[] { '-' }, 2);
+				Version = new Version(parts[0]);
+				Suffix = parts[1];
+			}
+			else
+			{
+				Version = new Version(version);
+			}
 		}
 
 		private static string ParseId(string id, out string prefix)

--- a/CCNet.Build.SetupPackages/PackageChecker.cs
+++ b/CCNet.Build.SetupPackages/PackageChecker.cs
@@ -68,7 +68,19 @@ namespace CCNet.Build.SetupPackages
 
 		public void Load()
 		{
-			m_localPackages = m_db.GetLatestVersions().ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
+			var allLocalPackages = m_db.GetLatestVersions().ToList();
+
+			m_localPackages = allLocalPackages
+				.Where(p => p.Branch == null)
+				.ToDictionary(p => p.Id, StringComparer.OrdinalIgnoreCase);
+
+			if (Args.BranchName != null)
+			{
+				foreach(var p in allLocalPackages.Where(p => p.Branch == Args.BranchName.ToLower()))
+				{
+					m_localPackages[p.Id] = p;
+				}
+			}
 		}
 
 		public bool IsLocal(string id)
@@ -101,7 +113,7 @@ namespace CCNet.Build.SetupPackages
 			return m_bundles.Contains(id);
 		}
 
-		public TargetFramework TargetFramework(string id)
+		public TargetFramework? TargetFramework(string id)
 		{
 			if (!IsLocal(id))
 				throw new InvalidOperationException("Target framework versions are available for local packages only.");

--- a/CCNet.Build.SetupPackages/Run/ReferencesHelper.cs
+++ b/CCNet.Build.SetupPackages/Run/ReferencesHelper.cs
@@ -65,7 +65,10 @@ Please add it as a NuGet reference first, and only after that you can convert it
 				m_log[name].ProjectReference = true;
 
 				var framework = m_checker.TargetFramework(name);
-				reference.ConvertToBinary(framework, name);
+				if (framework != null)
+				{
+					reference.ConvertToBinary(framework.Value, name);
+				}
 			}
 
 			Console.WriteLine("OK");

--- a/CCNet.Build.SetupProject/Args.cs
+++ b/CCNet.Build.SetupProject/Args.cs
@@ -18,6 +18,11 @@ namespace CCNet.Build.SetupProject
 			get { return Current.Get<string>("ProjectName"); }
 		}
 
+		public static string BranchName
+		{
+			get { return Current.IsEmpty("BranchName") ? null : Current.Get<string>("BranchName"); }
+		}
+
 		public static string PackageId
 		{
 			get { return Current.Get("PackageId", ProjectName); }

--- a/CCNet.Build.SetupProject/Program.Links.cs
+++ b/CCNet.Build.SetupProject/Program.Links.cs
@@ -6,6 +6,11 @@ namespace CCNet.Build.SetupProject
 {
 	public partial class Program
 	{
+		private static readonly string m_nugetLogo = $"{Config.NuGetUrl}/Content/Logos/nugetlogo.png";
+
+		private static readonly string m_confluenceLogo = "https://owl.cbsi.com/images/confluence_logo_landing.png";
+		private static readonly string m_confluencePageTemplate = "https://owl.cbsi.com/confluence/display/CCSSEDRU/{0}+{1}";
+
 		private static void RenderLinks()
 		{
 			List<dynamic> links;
@@ -60,13 +65,13 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"{Config.NuGetUrl}/packages/{Args.PackageId}/",
-					Image = $"{Config.NuGetUrl}/Content/Logos/nugetlogo.png"
+					Url = GetNugetUrl(),
+					Image = m_nugetLogo
 				},
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+library",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("library"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -77,8 +82,8 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+web+site",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("web+site"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -89,8 +94,8 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+web+service",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("web+service"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -101,8 +106,8 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+service",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("service"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -113,8 +118,8 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+console",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("console"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -125,8 +130,8 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+application",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("application"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -137,8 +142,8 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+cloud+role",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("cloud+role"),
+					Image = m_confluenceLogo
 				}
 			};
 		}
@@ -149,10 +154,32 @@ namespace CCNet.Build.SetupProject
 			{
 				new
 				{
-					Url = $"https://owl.cbsi.com/confluence/display/CCSSEDRU/{Args.ProjectName}+cloud+service",
-					Image = "https://owl.cbsi.com/images/confluence_logo_landing.png"
+					Url = GetConfluenceUrl("cloud+service"),
+					Image = m_confluenceLogo
 				}
 			};
+		}
+
+		private static object GetConfluenceUrl(string suffix)
+		{
+			string projectConfluenceName = Args.ProjectName;
+			if (Args.BranchName != null)
+			{
+				projectConfluenceName = $"~+{Args.BranchName}+~+{Args.ProjectName}";
+			}
+
+			return string.Format(m_confluencePageTemplate, projectConfluenceName, suffix);
+		}
+
+		private static object GetNugetUrl()
+		{
+			string url = $"{Config.NuGetUrl}/packages/{Args.PackageId}/";
+			if (Args.BranchName != null)
+			{
+				url = $"{Config.NuGetUrl}/private/{Args.BranchName}/packages/__{Args.BranchName.ToLower()}__{Args.PackageId}/";
+			}
+
+			return url;
 		}
 	}
 }


### PR DESCRIPTION
Support new templates for component page header: "~ branch_name ~ project_name project_type".
The generated markup for Confluence now is exactly the same as manually edited.
Fixed Summary and Area Confluence pages.
Added private NuGet source for projects having a custom branch.