### PR TITLE
Prevent of NuGet cache updating with branched packages.

### DIFF
--- a/CCNet.Build.SetupPackages/CCNet.Build.SetupPackages.csproj
+++ b/CCNet.Build.SetupPackages/CCNet.Build.SetupPackages.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -61,6 +62,7 @@
     <Compile Include="NuGet\PackagesConfig.cs" />
     <Compile Include="NuGet\NuGetReference.cs" />
     <Compile Include="Run\NuGetHelper.cs" />
+    <Compile Include="Run\NuGetSubstitute.cs" />
     <Compile Include="Run\PackagesHelper.cs" />
     <Compile Include="Run\ReferencesHelper.cs" />
     <Compile Include="Config.cs" />
@@ -74,6 +76,7 @@
   <ItemGroup>
     <None Include="App.config">
       <TransformOnBuild>true</TransformOnBuild>
+      <SubType>Designer</SubType>
     </None>
     <None Include="App.Debug.config">
       <DependentUpon>App.config</DependentUpon>

--- a/CCNet.Build.SetupPackages/Program.cs
+++ b/CCNet.Build.SetupPackages/Program.cs
@@ -54,6 +54,14 @@ namespace CCNet.Build.SetupPackages
 				references.Adjust();
 			}
 
+			if (Args.BranchName != null)
+			{
+				using (Execute.Step("RESTORE (BRANCH)"))
+				{
+					(new NuGetSubstitute(Config.NuGetDbConnection)).RestoreBranchedPackages();
+				}
+			}
+
 			using (Execute.Step("RESTORE"))
 			{
 				nuget.RestoreAll();

--- a/CCNet.Build.SetupPackages/Run/NuGetHelper.cs
+++ b/CCNet.Build.SetupPackages/Run/NuGetHelper.cs
@@ -84,16 +84,7 @@ namespace CCNet.Build.SetupPackages
 			string mainNuGetUrl = Args.NuGetUrl;
 			if (Args.BranchName != null)
 			{
-				var nuGetUrls = Args.NuGetUrl.Split(new[] { ';' });
-				string branchNuGetUrl = nuGetUrls[0];
-				mainNuGetUrl = nuGetUrls[1];
-
-				// we shouldn't cache branched components to avoid affe
-				Run(
-					@"restore ""{0}"" -PackagesDirectory ""{1}"" -Source ""{2}"" -MSBuildVersion 14 -NonInteractive -Verbosity Detailed -nocache",
-					Paths.PackagesConfig,
-					Args.PackagesPath,
-					branchNuGetUrl);
+				mainNuGetUrl = Args.NuGetUrl.Split(new[] { ';' })[1];
 			}
 
 			Run(

--- a/CCNet.Build.SetupPackages/Run/NuGetSubstitute.cs
+++ b/CCNet.Build.SetupPackages/Run/NuGetSubstitute.cs
@@ -1,0 +1,110 @@
+﻿using CCNet.Build.Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CCNet.Build.SetupPackages
+{
+	public class NuGetSubstitute
+	{
+		private readonly NuGetDb m_db;
+		private List<NuGetPackage> m_thisBranchPackages;
+
+		public NuGetSubstitute(string nugetDbConnection)
+		{
+			m_db = new NuGetDb(nugetDbConnection);
+
+			m_thisBranchPackages = m_db.GetLatestVersions()
+				.Where(p => p.Branch == Args.BranchName.ToLower())
+				.ToList();
+		}
+
+		private List<BinaryReference> GetProjectBinaryReferences()
+		{
+			var project = new ProjectDocument(Args.ProjectFile);
+			return project.GetBinaryReferences();
+		}
+		
+		public void RestoreBranchedPackages()
+		{
+			Console.WriteLine("Restoring packages...");
+
+			if (String.IsNullOrEmpty(Args.PackagesPath))
+				throw new InvalidOperationException("Packages path is not set.");
+
+			string mainNuGetUrl = Args.NuGetUrl;
+			if (Args.BranchName != null)
+			{
+				string branchNuGetUrl = Args.NuGetUrl.Split(new[] { ';' })[0];
+				var referenceNames = GetProjectBinaryReferences().Select(x => x.AssemblyName.Name).ToList();
+				var branchedPackages = m_thisBranchPackages.Where(x => referenceNames.Contains(x.Id)).ToList();
+
+				foreach (var package in branchedPackages)
+				{
+					InstallNuGutPackage(package, branchNuGetUrl);
+				}
+			}
+		}
+
+		private void InstallNuGutPackage(NuGetPackage package, string branchNuGetUrl)
+		{
+			var downloadUrl = $"{branchNuGetUrl}/package/__{package.Branch.ToLower()}__{package.Id}/{package.Version}";
+			var packageName = $"{Args.PackagesPath}\\{package.Id}.{package.Version}\\{package.Id}.{package.Version}.nupkg";
+
+			ClearPackage(packageName);
+			(new WebClient()).DownloadFile(downloadUrl, packageName);
+			UnZipPackage(packageName);
+		}
+
+		private void ClearPackage(string packageName)
+		{
+			var packagePath = Path.GetDirectoryName(packageName);
+
+			if (Directory.Exists(packagePath))
+			{
+				Directory.Delete(packagePath, true);
+			}
+
+			Directory.CreateDirectory(packagePath);
+
+			if (File.Exists(packageName))
+			{
+				File.Delete(packageName);
+			}
+		}
+
+		private void UnZipPackage(string packageName)
+		{
+			using (FileStream zipToOpen = new FileStream(packageName, FileMode.Open))
+			{
+				using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Update))
+				{
+					List<ZipArchiveEntry> entries = archive.Entries.Where(x => x.FullName.StartsWith("lib/")).ToList();
+					foreach (var entry in entries)
+					{
+						var entryName = Path.Combine(
+							Path.GetDirectoryName(packageName),
+							entry.FullName);
+
+						var entryPath = Path.GetDirectoryName(entryName);
+
+						if (!Directory.Exists(entryPath))
+						{
+							Directory.CreateDirectory(entryPath);
+						}
+
+						using (var fileStream = new FileStream(entryName, FileMode.Create, FileAccess.Write))
+						{
+							entry.Open().CopyTo(fileStream);
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I tried to isolate all my custom operations with NuGet within NuGetSubstitute class.  It should help to clearly refactor this in future.